### PR TITLE
Switch Redux middleware to redux-saga

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "tslint-loader": "^3.5.3",
     "tslint-react": "^3.2.0",
     "typescript": "^2.7.0-dev.20180122",
+    "typescript-fsa": "^2.5.0",
+    "typescript-fsa-reducers": "^0.4.5",
     "url-loader": "0.5.9",
     "webpack": "^3.10.0",
     "webpack-dev-server": "2.7.1",

--- a/src/actions/github.ts
+++ b/src/actions/github.ts
@@ -1,54 +1,21 @@
-import { ThunkAction } from 'redux-thunk';
+import actionCreatorFactory from 'typescript-fsa';
 
-import * as constants from 'constants/github';
-import { GitHubApi, Member, User } from 'services/github';
-import { AbstractAction } from './';
+import { Member, User } from 'services/github';
 
-export interface GitHubAction extends AbstractAction {
-  payload: {
-    members: Member[],
-    users: User[],
-  };
-}
+const actionCreator = actionCreatorFactory('GITHUB');
 
-// Set Members
-export const setMembers = (members: Member[]) => ({
-  type: constants.SET_MEMBERS,
-  payload: { members },
-});
+export const loadMembers = actionCreator<{
+  organization: string,
+}>('LOAD_MEMBERS');
 
-// Set Members
-export const setUsers = (users: User[]) => ({
-  type: constants.SET_USERS,
-  payload: { users },
-});
+export const setMembers = actionCreator<{
+  members: Member[],
+}>('SET_MEMBERS');
 
-// Get Organization Members
-export const getOrganizationMembers = (): ThunkAction<void, {}, {}> =>
-async (dispatch) => {
-  let members: Member[] = [];
+export const searchUsers = actionCreator<{
+  query: string,
+}>('SEARCH_USERS');
 
-  try {
-    const api = new GitHubApi();
-    members = await api.getOrganizationMembers('globis-org');
-  } catch (err) {
-    throw(err);
-  }
-
-  dispatch(setMembers(members));
-};
-
-// Search Users
-export const searchUsers = (login: string): ThunkAction<void, {}, {}> =>
-async (dispatch) => {
-  let users: User[] = [];
-
-  try {
-    const api = new GitHubApi();
-    users = await api.searchUsers(login);
-  } catch (err) {
-    throw(err);
-  }
-
-  dispatch(setUsers(users));
-};
+export const setUsers = actionCreator<{
+  users: User[],
+}>('SET_USERS');

--- a/src/components/Globis/Members/index.tsx
+++ b/src/components/Globis/Members/index.tsx
@@ -10,7 +10,7 @@ import './index.css';
 
 export interface GlobisMembersProps extends InjectedTranslateProps {
   members: Member[];
-  getOrganizationMembers?(): any;
+  loadMembers?(query: string): any;
 }
 
 const GlobisMembers: React.SFC<GlobisMembersProps> = ({ t, members }) => (

--- a/src/constants/github.ts
+++ b/src/constants/github.ts
@@ -1,2 +1,0 @@
-export const SET_MEMBERS = 'SET_MEMBERS';
-export const SET_USERS = 'SET_USERS';

--- a/src/containers/Globis/Members/index.tsx
+++ b/src/containers/Globis/Members/index.tsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { compose, lifecycle, pure } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
 
-import { getOrganizationMembers } from 'actions/github';
+import { loadMembers } from 'actions/github';
 import GlobisMembers, { GlobisMembersProps } from 'components/Globis/Members';
 import { State } from 'reducers';
 
@@ -11,7 +11,7 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<{}>) => (
-  bindActionCreators({ getOrganizationMembers }, dispatch)
+  bindActionCreators({ loadMembers }, dispatch)
 );
 
 export default compose(
@@ -21,8 +21,8 @@ export default compose(
   ),
   lifecycle<GlobisMembersProps, {}, {}>({
     componentWillMount() {
-      if (this.props.getOrganizationMembers) {
-        this.props.getOrganizationMembers();
+      if (this.props.loadMembers) {
+        this.props.loadMembers('globis-org');
       }
     },
   }),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,24 +1,32 @@
 import { createBrowserHistory as createHistory } from 'history';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { applyMiddleware, createStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import thunkMiddleware from 'redux-thunk';
-import 'semantic-ui-css/semantic.min.css';
+import createSagaMiddleware from 'redux-saga';
 
-import { I18nextProvider } from 'react-i18next';
 import reducer from 'reducers';
+import rootTask from 'tasks';
 import App from './App';
 import i18n from './i18n';
-import './index.css';
 import registerServiceWorker from './registerServiceWorker';
 
+import 'semantic-ui-css/semantic.min.css';
+import './index.css';
+
+const sagaMiddleware = createSagaMiddleware();
 const store = createStore(
   reducer,
-  composeWithDevTools(applyMiddleware(thunkMiddleware)),
+  composeWithDevTools(
+    applyMiddleware(
+      sagaMiddleware,
+    ),
+  ),
 );
+sagaMiddleware.run(rootTask);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/reducers/github.ts
+++ b/src/reducers/github.ts
@@ -1,37 +1,26 @@
-import { Reducer } from 'redux';
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
-import { GitHubAction } from 'actions/github';
-import * as constants from 'constants/github';
+import * as actions from 'actions/github';
 import { Member, User } from 'services/github';
 
 export interface GithubState {
-  members: Member[];
-  users: User[];
+  members?: Member[];
+  users?: User[];
 }
 
-const initialState = {
+const initialState: GithubState = {
   members: [],
   users: [],
  };
 
-const githubReducer: Reducer<GithubState> = (
-  state: GithubState = initialState,
-  action: GitHubAction,
-) => {
-  switch (action.type) {
-  case constants.SET_MEMBERS:
-    return {
-      ...state,
-      members: action.payload.members,
-    };
-  case constants.SET_USERS:
-    return {
-      ...state,
-      users: action.payload.users,
-    };
-  default:
-    return state;
-  }
-};
+const githubReducer = reducerWithInitialState(initialState)
+  .case(
+    actions.setMembers,
+    (state, { members }) => ({ state, members }),
+  )
+  .case(
+    actions.setUsers,
+    (state, { users }) => ({ state, users }),
+  );
 
 export default githubReducer;

--- a/src/tasks/github.ts
+++ b/src/tasks/github.ts
@@ -1,0 +1,48 @@
+import { SagaIterator } from 'redux-saga';
+import { all, call, fork, put, take } from 'redux-saga/effects';
+
+import * as actions from 'actions/github';
+import { GitHubApi } from 'services/github';
+
+function* watchLoadMembers(): SagaIterator {
+  while (true) {
+    const action = yield take(actions.loadMembers);
+
+    try {
+      const api = new GitHubApi();
+      const members = yield call(
+        api.getOrganizationMembers,
+        action.payload,
+      );
+      yield put(actions.setMembers({ members }));
+
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+function* watchLoadSearchUsers(): SagaIterator {
+  while (true) {
+    const action = yield take(actions.searchUsers);
+
+    try {
+      const api = new GitHubApi();
+      const users = yield call(
+        api.searchUsers,
+        action.payload,
+      );
+      yield put(actions.setUsers({ users }));
+
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+export default function* githubTasks() {
+  yield all([
+    fork(watchLoadMembers),
+    fork(watchLoadSearchUsers),
+  ]);
+}

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,0 +1,8 @@
+import { all, fork } from 'redux-saga/effects';
+import githubTasks from './github';
+
+export default function* rootTask() {
+  yield all([
+    fork(githubTasks),
+  ]);
+}


### PR DESCRIPTION
Redux のミドルウェアを [redux-saga](https://github.com/redux-saga/redux-saga) に切り替えました。
なお Action のフォーマットを Flux Style Action に強制させるため、

- [typescript-fsa](https://www.npmjs.com/package/typescript-fsa)
- [typescript-fsa-reducers](https://www.npmjs.com/package/typescript-fsa-reducers)

を併せて適用しました。